### PR TITLE
Output commit message title and body

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ This action outputs the git message associated with the current SHA
 
 The git-message
 
+### `title`
+
+The title of the git-message, i.e. the first line
+
+### `body`
+
+The body of the git-message, i.e. everything but the first line
+
 ## Example usage
 Without SHA:
 ```

--- a/index.js
+++ b/index.js
@@ -8,6 +8,12 @@ try {
       throw err;
     }
     core.setOutput("git-message", stdout);
+
+    const lines = stdout.split("\n");
+    const title = lines.shift();
+    const body = lines.join("\n");
+    core.setOutput("title", title);
+    core.setOutput("body", body);
   });
 } catch (error) {
   core.setFailed(error.message);


### PR DESCRIPTION
Closes #5, extracts from the `git-message` the message title and body and outputs them under those names. Updated the README accordingly. Let me know if you prefer other names than just "title" and "body".