### PR TITLE
Escape user input

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,10 @@
 const core = require('@actions/core');
 const { exec } = require('child_process');
+const { quote } = require('shescape');
 
 try {
   const sha = core.getInput('sha') || process.env.GITHUB_SHA;
-  exec(`git log --format=%B -n 1 ${sha}`, (err, stdout, stderr) => {
+  exec(`git log --format=%B -n 1 ${quote(sha)}`, (err, stdout, stderr) => {
     if (err) {
       throw err;
     }

--- a/node_modules/shescape/CHANGELOG.md
+++ b/node_modules/shescape/CHANGELOG.md
@@ -1,0 +1,75 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog], and this project adheres to [Semantic
+Versioning].
+
+## [Unreleased]
+
+- _No changes yet_
+
+## [1.2.1] - 2021-04-24
+
+- Provide TypeScript type definitions.
+- Update documentation to use ECMAScript module in examples.
+
+## [1.2.0] - 2021-04-14
+
+- Provide native ECMAScript module source files.
+
+## [1.1.3] - 2021-03-13
+
+- Strip null characters from arguments.
+
+## [1.1.2] - 2021-01-07
+
+- Add in-source JSDoc documentation.
+
+## [1.1.1] - 2020-12-30
+
+- Improve error message when a value is not stringable.
+
+## [1.1.0] - 2020-12-22
+
+- Add `escapeAll` function to escape an array of arguments.
+- Recommend usage of `escapeAll` when using `fork`/`spawn`/`execFile`.
+
+## [1.0.0] - 2020-12-10
+
+- (!) Remove ability to call `shescape()` directly.
+- (!) Automatically convert input to array in `quoteAll()`.
+- Fix numbering in documentation's "Install" section.
+
+## [0.4.1] - 2020-12-09
+
+- Support non-string values as arguments.
+
+## [0.4.0] - 2020-12-08
+
+- Add `quoteAll` function to quote and escape an array of arguments.
+- Create website with full documentation ([link](https://ericcornelissen.github.io/shescape/)).
+
+## [0.3.1] - 2020-12-07
+
+- Deprecate calling `shescape()` directly.
+
+## [0.3.0] - 2020-12-07
+
+- Add `escape` function to escape an argument (same as `shescape()`).
+- Add `quote` function to quote and escape an argument.
+
+## [0.2.1] - 2020-11-07
+
+- Fix missing released files.
+
+## [0.2.0] - 2020-11-07
+
+- Add support for escaping of double quotes on Windows.
+
+## [0.1.0] - 2020-11-06
+
+- Escape individual shell arguments.
+
+[keep a changelog]: https://keepachangelog.com/en/1.0.0/
+[semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/node_modules/shescape/LICENSE
+++ b/node_modules/shescape/LICENSE
@@ -1,0 +1,373 @@
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/node_modules/shescape/README.md
+++ b/node_modules/shescape/README.md
@@ -1,0 +1,38 @@
+# Shescape
+
+[![GitHub Actions][ci-image]][ci-url]
+[![Coverage Report][coverage-image]][coverage-url]
+[![quality Report][quality-image]][quality-url]
+[![NPM Package][npm-image]][npm-url]
+[![Documentation][docs-image]][docs-url]
+
+A simple shell escape package for JavaScript. Use it to escape user-controlled
+inputs to shell commands to prevent [shell injection].
+
+## Example
+
+> Please read [the full documentation][docs-url] for more information.
+
+Below is a basic example of how to use _Shescape_. In this example `spawn` is
+used to invoke a shell command and `shescape.escapeAll` is used to escape any
+_dangerous_ character in any of the arguments specified by the array
+`userInput`.
+
+```js
+import cp from "child_process";
+import * as shescape from "shescape";
+
+cp.spawn("command", shescape.escapeAll(userInput), options);
+```
+
+[shell injection]: https://portswigger.net/web-security/os-command-injection
+[ci-url]: https://github.com/ericcornelissen/shescape/actions?query=workflow%3A%22Test+and+Lint%22+branch%3Amain
+[ci-image]: https://img.shields.io/github/workflow/status/ericcornelissen/shescape/Test%20and%20Lint/main?logo=github
+[coverage-url]: https://codecov.io/gh/ericcornelissen/shescape
+[coverage-image]: https://codecov.io/gh/ericcornelissen/shescape/branch/main/graph/badge.svg
+[quality-url]: https://codeclimate.com/github/ericcornelissen/shescape/maintainability
+[quality-image]: https://api.codeclimate.com/v1/badges/6eb1a10f41cf6950b6ce/maintainability
+[npm-url]: https://www.npmjs.com/package/shescape
+[npm-image]: https://img.shields.io/npm/v/shescape.svg
+[docs-url]: https://ericcornelissen.github.io/shescape/
+[docs-image]: https://img.shields.io/badge/read-the%20docs-informational

--- a/node_modules/shescape/SECURITY.md
+++ b/node_modules/shescape/SECURITY.md
@@ -1,0 +1,30 @@
+# Security Policy
+
+## Supported Versions
+
+The table below tells you which version of the _Shescape_ are currently being
+supported with security updates.
+
+| Version | Supported          |
+| ------: | ------------------ |
+|   1.x.x | :white_check_mark: |
+|   0.x.x | :x:                |
+
+## Reporting a Vulnerability
+
+The maintainers of the _Shescape_ take security bugs very seriously. We
+appreciate your efforts to responsibly disclose your findings. Due to the
+non-funded open-source nature of this project, we take a best-efforts approach
+when it comes to engaging with (security) reports.
+
+To report a security issue, send an email to [security@ericcornelissen.dev] and
+include the words _"SECURITY"_ and _"Shescape"_ in the subject line. Please
+do not open a regular issue or Pull Request in the public repository.
+
+## Acknowledgments
+
+We would like to publicly thank the following reporters:
+
+- _None yet_
+
+[security@ericcornelissen.dev]: mailto:security@ericcornelissen.dev?subject=SECURITY%20%28Shescape%29

--- a/node_modules/shescape/index.cjs
+++ b/node_modules/shescape/index.cjs
@@ -1,0 +1,278 @@
+/******/ (() => { // webpackBootstrap
+/******/ 	"use strict";
+/******/ 	// The require scope
+/******/ 	var __nccwpck_require__ = {};
+/******/ 	
+/************************************************************************/
+/******/ 	/* webpack/runtime/define property getters */
+/******/ 	(() => {
+/******/ 		// define getter functions for harmony exports
+/******/ 		__nccwpck_require__.d = (exports, definition) => {
+/******/ 			for(var key in definition) {
+/******/ 				if(__nccwpck_require__.o(definition, key) && !__nccwpck_require__.o(exports, key)) {
+/******/ 					Object.defineProperty(exports, key, { enumerable: true, get: definition[key] });
+/******/ 				}
+/******/ 			}
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/hasOwnProperty shorthand */
+/******/ 	(() => {
+/******/ 		__nccwpck_require__.o = (obj, prop) => (Object.prototype.hasOwnProperty.call(obj, prop))
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/make namespace object */
+/******/ 	(() => {
+/******/ 		// define __esModule on exports
+/******/ 		__nccwpck_require__.r = (exports) => {
+/******/ 			if(typeof Symbol !== 'undefined' && Symbol.toStringTag) {
+/******/ 				Object.defineProperty(exports, Symbol.toStringTag, { value: 'Module' });
+/******/ 			}
+/******/ 			Object.defineProperty(exports, '__esModule', { value: true });
+/******/ 		};
+/******/ 	})();
+/******/ 	
+/******/ 	/* webpack/runtime/compat */
+/******/ 	
+/******/ 	if (typeof __nccwpck_require__ !== 'undefined') __nccwpck_require__.ab = __dirname + "/";/************************************************************************/
+var __webpack_exports__ = {};
+// ESM COMPAT FLAG
+__nccwpck_require__.r(__webpack_exports__);
+
+// EXPORTS
+__nccwpck_require__.d(__webpack_exports__, {
+  "escape": () => (/* binding */ index_escape),
+  "escapeAll": () => (/* binding */ escapeAll),
+  "quote": () => (/* binding */ quote),
+  "quoteAll": () => (/* binding */ quoteAll)
+});
+
+;// CONCATENATED MODULE: external "os"
+const external_os_namespaceObject = require("os");;
+;// CONCATENATED MODULE: ./src/constants.js
+/**
+ * @overview Contains constants that may be used in multiple modules.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+/**
+ * @constant {string} typeError The error message for incorrect parameter types.
+ */
+const typeError =
+  "Shescape requires strings or values that can be converted into a string using .toString()";
+
+/**
+ * @constant {string} win32 The string identifying Windows systems.
+ */
+const win32 = "win32";
+
+;// CONCATENATED MODULE: ./src/unix.js
+/**
+ * @overview Contains functionality specifically for Unix systems.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+/**
+ * Escape a shell argument.
+ *
+ * @param {string} arg The argument to escape.
+ * @returns {string} The escaped argument.
+ */
+function escapeShellArg(arg) {
+  return arg.replace(/\u{0}/gu, "").replace(/'/g, `'\\''`);
+}
+
+;// CONCATENATED MODULE: ./src/win.js
+/**
+ * @overview Contains functionality specifically for Windows systems.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+/**
+ * Escape a shell argument.
+ *
+ * @param {string} arg The argument to escape.
+ * @returns {string} The escaped argument.
+ */
+function win_escapeShellArg(arg) {
+  return arg.replace(/\u{0}/gu, "").replace(/"/g, `""`);
+}
+
+;// CONCATENATED MODULE: ./src/main.js
+/**
+ * @overview Contains functionality to escape and quote shell arguments on any
+ * operating system.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+
+
+
+
+/**
+ * Check if a value can be converted into a string.
+ *
+ * @param {any} value The value of interest.
+ * @returns {boolean} `true` iff `value` can be converted into a string.
+ */
+function isStringable(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  return typeof value.toString === "function";
+}
+
+/**
+ * Take a value and escape any dangerous characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to escape.
+ * @param {string} platform The platform to escape the argument for.
+ * @returns {string} The escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ */
+function escapeShellArgByPlatform(arg, platform) {
+  if (!isStringable(arg)) {
+    throw new TypeError(typeError);
+  }
+
+  const argAsString = arg.toString();
+  switch (platform) {
+    case win32:
+      return win_escapeShellArg(argAsString);
+    default:
+      return escapeShellArg(argAsString);
+  }
+}
+
+/**
+ * Take a value, put OS-specific quotes around it, and escape any dangerous
+ * characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to escape and quote.
+ * @param {string} platform The platform to escape and quote the argument for.
+ * @returns {string} The escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ */
+function quoteShellArgByPlatform(arg, platform) {
+  const safeArg = escapeShellArgByPlatform(arg, platform);
+  switch (platform) {
+    case win32:
+      return `"${safeArg}"`;
+    default:
+      return `'${safeArg}'`;
+  }
+}
+
+;// CONCATENATED MODULE: ./index.js
+/**
+ * A simple shell escape package. Use it to escape user-controlled inputs to
+ * shell commands to prevent shell injection.
+ *
+ * @example
+ *   import cp from "child_process";
+ *   import * as shescape from "shescape";
+ *   cp.spawn("command", shescape.escapeAll(userInput), options);
+ *
+ * @module shescape
+ * @version 1.2.1
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+
+
+
+
+/**
+ * Take a single value, the argument, and escape any dangerous characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to escape.
+ * @returns {string} The escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ * @since 0.1.0
+ */
+function index_escape(arg) {
+  const platform = external_os_namespaceObject.platform();
+  return escapeShellArgByPlatform(arg, platform);
+}
+
+/**
+ * Take a array of values, the arguments, and escape any dangerous characters in
+ * every argument.
+ *
+ * Non-array inputs will be converted to one-value arrays and non-string values
+ * will be converted to strings using a `toString()` method.
+ *
+ * @param {string[]} args The arguments to escape.
+ * @returns {string[]} The escaped arguments.
+ * @throws {TypeError} One of the arguments is not stringable.
+ * @since 1.1.0
+ */
+function escapeAll(args) {
+  if (!Array.isArray(args)) args = [args];
+
+  const platform = external_os_namespaceObject.platform();
+  const result = [];
+  for (const arg of args) {
+    const safeArg = escapeShellArgByPlatform(arg, platform);
+    result.push(safeArg);
+  }
+
+  return result;
+}
+
+/**
+ * Take a single value, the argument, put OS-specific quotes around it and
+ * escape any dangerous characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ * @since 0.3.0
+ */
+function quote(arg) {
+  const platform = external_os_namespaceObject.platform();
+  return quoteShellArgByPlatform(arg, platform);
+}
+
+/**
+ * Take an array of values, the arguments, put OS-specific quotes around every
+ * argument and escape any dangerous characters in every argument.
+ *
+ * Non-array inputs will be converted to one-value arrays and non-string values
+ * will be converted to strings using a `toString()` method.
+ *
+ * @param {string[]} args The arguments to quote and escape.
+ * @returns {string[]} The quoted and escaped arguments.
+ * @throws {TypeError} One of the arguments is not stringable.
+ * @since 0.4.0
+ */
+function quoteAll(args) {
+  if (!Array.isArray(args)) args = [args];
+
+  const platform = external_os_namespaceObject.platform();
+  const result = [];
+  for (const arg of args) {
+    const safeArg = quoteShellArgByPlatform(arg, platform);
+    result.push(safeArg);
+  }
+
+  return result;
+}
+
+module.exports = __webpack_exports__;
+/******/ })()
+;

--- a/node_modules/shescape/index.d.ts
+++ b/node_modules/shescape/index.d.ts
@@ -1,0 +1,13 @@
+/**
+ * @overview Contains TypeScript type definitions for Shescape.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+export function escape(arg: string): string;
+
+export function escapeAll(arg: string[]): string[];
+
+export function quote(arg: string): string;
+
+export function quoteAll(arg: string[]): string[];

--- a/node_modules/shescape/index.js
+++ b/node_modules/shescape/index.js
@@ -1,0 +1,99 @@
+/**
+ * A simple shell escape package. Use it to escape user-controlled inputs to
+ * shell commands to prevent shell injection.
+ *
+ * @example
+ *   import cp from "child_process";
+ *   import * as shescape from "shescape";
+ *   cp.spawn("command", shescape.escapeAll(userInput), options);
+ *
+ * @module shescape
+ * @version 1.2.1
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+import os from "os";
+
+import * as main from "./src/main.js";
+
+/**
+ * Take a single value, the argument, and escape any dangerous characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to escape.
+ * @returns {string} The escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ * @since 0.1.0
+ */
+export function escape(arg) {
+  const platform = os.platform();
+  return main.escapeShellArgByPlatform(arg, platform);
+}
+
+/**
+ * Take a array of values, the arguments, and escape any dangerous characters in
+ * every argument.
+ *
+ * Non-array inputs will be converted to one-value arrays and non-string values
+ * will be converted to strings using a `toString()` method.
+ *
+ * @param {string[]} args The arguments to escape.
+ * @returns {string[]} The escaped arguments.
+ * @throws {TypeError} One of the arguments is not stringable.
+ * @since 1.1.0
+ */
+export function escapeAll(args) {
+  if (!Array.isArray(args)) args = [args];
+
+  const platform = os.platform();
+  const result = [];
+  for (const arg of args) {
+    const safeArg = main.escapeShellArgByPlatform(arg, platform);
+    result.push(safeArg);
+  }
+
+  return result;
+}
+
+/**
+ * Take a single value, the argument, put OS-specific quotes around it and
+ * escape any dangerous characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to quote and escape.
+ * @returns {string} The quoted and escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ * @since 0.3.0
+ */
+export function quote(arg) {
+  const platform = os.platform();
+  return main.quoteShellArgByPlatform(arg, platform);
+}
+
+/**
+ * Take an array of values, the arguments, put OS-specific quotes around every
+ * argument and escape any dangerous characters in every argument.
+ *
+ * Non-array inputs will be converted to one-value arrays and non-string values
+ * will be converted to strings using a `toString()` method.
+ *
+ * @param {string[]} args The arguments to quote and escape.
+ * @returns {string[]} The quoted and escaped arguments.
+ * @throws {TypeError} One of the arguments is not stringable.
+ * @since 0.4.0
+ */
+export function quoteAll(args) {
+  if (!Array.isArray(args)) args = [args];
+
+  const platform = os.platform();
+  const result = [];
+  for (const arg of args) {
+    const safeArg = main.quoteShellArgByPlatform(arg, platform);
+    result.push(safeArg);
+  }
+
+  return result;
+}

--- a/node_modules/shescape/package.json
+++ b/node_modules/shescape/package.json
@@ -1,0 +1,86 @@
+{
+  "_from": "shescape",
+  "_id": "shescape@1.2.1",
+  "_inBundle": false,
+  "_integrity": "sha512-CFhs8+Pg50rDJkXxpcMtI5Wd32ghNhgmgZIoTMMsM8LxIQzLZ4BFqI59+TCVxNNr2vZ/I10WPylAYWuKZ/9brA==",
+  "_location": "/shescape",
+  "_phantomChildren": {},
+  "_requested": {
+    "type": "tag",
+    "registry": true,
+    "raw": "shescape",
+    "name": "shescape",
+    "escapedName": "shescape",
+    "rawSpec": "",
+    "saveSpec": null,
+    "fetchSpec": "latest"
+  },
+  "_requiredBy": [
+    "#USER",
+    "/"
+  ],
+  "_resolved": "https://registry.npmjs.org/shescape/-/shescape-1.2.1.tgz",
+  "_shasum": "b9766dfbeff8b21529a63c27770910fdc17f487b",
+  "_spec": "shescape",
+  "_where": "/media/win/workspace/git-message-action",
+  "author": {
+    "name": "Eric Cornelissen",
+    "email": "ericornelissen@gmail.com",
+    "url": "https://ericcornelissen.dev/"
+  },
+  "bugs": {
+    "url": "https://github.com/ericcornelissen/shescape/issues"
+  },
+  "bundleDependencies": false,
+  "deprecated": false,
+  "description": "simple shell escape library",
+  "devDependencies": {
+    "@stryker-mutator/core": "^4.6.0",
+    "@vercel/ncc": "^0.28.3",
+    "c8": "^7.7.1",
+    "husky": "^6.0.0",
+    "is-ci": "^3.0.0",
+    "jsfuzz": "^1.0.14",
+    "mocha": "^8.2.0",
+    "pinst": "^2.1.1",
+    "prettier": "^2.1.2",
+    "sinon": "^10.0.0"
+  },
+  "engines": {
+    "node": ">=10.13.0"
+  },
+  "exports": {
+    "import": "./index.js",
+    "require": "./index.cjs"
+  },
+  "homepage": "https://ericcornelissen.github.io/shescape/",
+  "keywords": [
+    "shell",
+    "escape",
+    "injection"
+  ],
+  "license": "MPL-2.0",
+  "main": "./index.cjs",
+  "name": "shescape",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ericcornelissen/shescape.git"
+  },
+  "scripts": {
+    "_postinstall": "is-ci || husky install",
+    "clean": "rm -rf .corpus/ .nyc_output/ .stryker-tmp/ reports/ crash-* index.cjs",
+    "format": "prettier --write ./**/*.{cjs,js,md,yml}",
+    "fuzz": "jsfuzz ./test/index.fuzz.cjs ./.corpus",
+    "lint": "prettier --check ./**/*.{js,md,yml}",
+    "postpublish": "pinst --enable",
+    "prefuzz": "npm run transpile",
+    "prepublishOnly": "pinst --disable && npm run transpile",
+    "test": "mocha test/**/*.test.js",
+    "test:coverage": "c8 --reports-dir=reports/coverage --reporter=lcov --reporter=text npm run test",
+    "test:mutation": "stryker run",
+    "transpile": "ncc build index.js && mv dist/index.js index.cjs && rm -rf dist"
+  },
+  "type": "module",
+  "typings": "index.d.ts",
+  "version": "1.2.1"
+}

--- a/node_modules/shescape/src/constants.js
+++ b/node_modules/shescape/src/constants.js
@@ -1,0 +1,16 @@
+/**
+ * @overview Contains constants that may be used in multiple modules.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+/**
+ * @constant {string} typeError The error message for incorrect parameter types.
+ */
+export const typeError =
+  "Shescape requires strings or values that can be converted into a string using .toString()";
+
+/**
+ * @constant {string} win32 The string identifying Windows systems.
+ */
+export const win32 = "win32";

--- a/node_modules/shescape/src/main.js
+++ b/node_modules/shescape/src/main.js
@@ -1,0 +1,69 @@
+/**
+ * @overview Contains functionality to escape and quote shell arguments on any
+ * operating system.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+import { typeError, win32 } from "./constants.js";
+import * as unix from "./unix.js";
+import * as win from "./win.js";
+
+/**
+ * Check if a value can be converted into a string.
+ *
+ * @param {any} value The value of interest.
+ * @returns {boolean} `true` iff `value` can be converted into a string.
+ */
+function isStringable(value) {
+  if (value === undefined || value === null) {
+    return false;
+  }
+
+  return typeof value.toString === "function";
+}
+
+/**
+ * Take a value and escape any dangerous characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to escape.
+ * @param {string} platform The platform to escape the argument for.
+ * @returns {string} The escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ */
+export function escapeShellArgByPlatform(arg, platform) {
+  if (!isStringable(arg)) {
+    throw new TypeError(typeError);
+  }
+
+  const argAsString = arg.toString();
+  switch (platform) {
+    case win32:
+      return win.escapeShellArg(argAsString);
+    default:
+      return unix.escapeShellArg(argAsString);
+  }
+}
+
+/**
+ * Take a value, put OS-specific quotes around it, and escape any dangerous
+ * characters.
+ *
+ * Non-string inputs will be converted to strings using a `toString()` method.
+ *
+ * @param {string} arg The argument to escape and quote.
+ * @param {string} platform The platform to escape and quote the argument for.
+ * @returns {string} The escaped argument.
+ * @throws {TypeError} The argument is not stringable.
+ */
+export function quoteShellArgByPlatform(arg, platform) {
+  const safeArg = escapeShellArgByPlatform(arg, platform);
+  switch (platform) {
+    case win32:
+      return `"${safeArg}"`;
+    default:
+      return `'${safeArg}'`;
+  }
+}

--- a/node_modules/shescape/src/unix.js
+++ b/node_modules/shescape/src/unix.js
@@ -1,0 +1,15 @@
+/**
+ * @overview Contains functionality specifically for Unix systems.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+/**
+ * Escape a shell argument.
+ *
+ * @param {string} arg The argument to escape.
+ * @returns {string} The escaped argument.
+ */
+export function escapeShellArg(arg) {
+  return arg.replace(/\u{0}/gu, "").replace(/'/g, `'\\''`);
+}

--- a/node_modules/shescape/src/win.js
+++ b/node_modules/shescape/src/win.js
@@ -1,0 +1,15 @@
+/**
+ * @overview Contains functionality specifically for Windows systems.
+ * @license MPL-2.0
+ * @author Eric Cornelissen <ericornelissen@gmail.com>
+ */
+
+/**
+ * Escape a shell argument.
+ *
+ * @param {string} arg The argument to escape.
+ * @returns {string} The escaped argument.
+ */
+export function escapeShellArg(arg) {
+  return arg.replace(/\u{0}/gu, "").replace(/"/g, `""`);
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,11 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/@actions/core/-/core-1.2.2.tgz",
       "integrity": "sha512-IbCx7oefq+Gi6FWbSs2Fnw8VkEI6Y4gvjrYprY3RV//ksq/KPMlClOerJ4jRosyal6zkUIc8R9fS/cpRMlGClg=="
+    },
+    "shescape": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.2.1.tgz",
+      "integrity": "sha512-CFhs8+Pg50rDJkXxpcMtI5Wd32ghNhgmgZIoTMMsM8LxIQzLZ4BFqI59+TCVxNNr2vZ/I10WPylAYWuKZ/9brA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
   },
   "homepage": "https://github.com/kceb/git-message-action#readme",
   "dependencies": {
-    "@actions/core": "^1.2.2"
+    "@actions/core": "^1.2.2",
+    "shescape": "^1.2.1"
   }
 }


### PR DESCRIPTION
This updates the source of this Action to escape [the user input](https://github.com/kceb/git-message-action/tree/72a1d9c9f8ecbab578d7fd58251808d40b4faba3#sha) to the Action. This relates to [this Security Advisory](https://github.com/ericcornelissen/git-tag-annotation-action/security/advisories/GHSA-hgx2-4pp9-357g) of a related Action I created based on this Action.

In summary, this Action allows for (unexpected) arbitrary code execution if the `sha` input is controlled by a nefarious actor. For example, the following snippet would include the contents of the directory in which this Action is run in it's output.

```yaml
- uses: kceb/git-message-action@v1
  id: before
  with:
    sha: '0a4e2e9cd75d57f8943b034da6fd3ef158681737 && ls -al'
```

However, one can imagine a Workflow where the `sha` input comes from, for example, a third action:

```yaml
- uses: not/malicous@v1
  id: get_sha
- uses: kceb/git-message-action@v1
  id: before
  with:
    sha: ${{ steps.get_sha.outputs.really_just_a_sha }}
```

---

_I have brought up this potential vulnerability to this Action's maintainer on 27-October-2020 but have not received a response, hence I decided to publish this public fix over 6 months later_