### PR TITLE
chore(deps): bump shescape from 1.5.8 to 1.5.10

### DIFF
--- a/node_modules/shescape/CHANGELOG.md
+++ b/node_modules/shescape/CHANGELOG.md
@@ -9,6 +9,20 @@ Versioning].
 
 - _No changes yet_
 
+## [1.5.10] - 2022-08-21
+
+- Fix potential polynomial backtracking in regular expression for Bash escaping
+  with `{interpolation:true}`. ([#373])
+- Fix potential quadratic runtime regular expressions for Bash escaping with
+  `{interpolation:true}`. ([#373])
+
+## [1.5.9] - 2022-07-28
+
+- Fix escaping characters after `U+0085` with `{interpolation:true}` for
+  PowerShell on Windows systems. ([#354])
+- Improve performance of escaping for Dash. ([#336])
+- Include full documentation in published package. ([#350])
+
 ## [1.5.8] - 2022-07-15
 
 - Fix escaping of line feed characters for Bash, Dash, and Zsh on Unix
@@ -161,5 +175,9 @@ Versioning].
 [#322]: https://github.com/ericcornelissen/shescape/pull/322
 [#324]: https://github.com/ericcornelissen/shescape/pull/324
 [#332]: https://github.com/ericcornelissen/shescape/pull/332
+[#336]: https://github.com/ericcornelissen/shescape/pull/336
+[#350]: https://github.com/ericcornelissen/shescape/pull/350
+[#354]: https://github.com/ericcornelissen/shescape/pull/354
+[#373]: https://github.com/ericcornelissen/shescape/pull/373
 [keep a changelog]: https://keepachangelog.com/en/1.0.0/
 [semantic versioning]: https://semver.org/spec/v2.0.0.html

--- a/node_modules/shescape/README.md
+++ b/node_modules/shescape/README.md
@@ -3,7 +3,7 @@
 [![GitHub Actions][ci-image]][ci-url]
 [![Coverage Report][coverage-image]][coverage-url]
 [![Mutation Report][mutation-image]][mutation-url]
-[![quality Report][quality-image]][quality-url]
+[![Quality Report][quality-image]][quality-url]
 [![NPM Package][npm-image]][npm-url]
 
 A simple shell escape package for JavaScript. Use it to escape user-controlled
@@ -209,6 +209,11 @@ console.log(safeArgs);
 > individual non-string values to strings if needed and will error if this is
 > not possible. You are responsible for verifying the input makes sense.
 
+---
+
+Please [open an issue] if you found a mistake or if you have a suggestion for
+how to improve the documentation.
+
 [ci-url]: https://github.com/ericcornelissen/shescape/actions/workflows/push-checks.yml
 [ci-image]: https://img.shields.io/github/workflow/status/ericcornelissen/shescape/Push%20checks/main?logo=github
 [coverage-url]: https://codecov.io/gh/ericcornelissen/shescape
@@ -222,6 +227,7 @@ console.log(safeArgs);
 [an issue]: https://github.com/ericcornelissen/shescape/issues
 [changelog]: https://github.com/ericcornelissen/shescape/blob/main/CHANGELOG.md
 [license]: https://github.com/ericcornelissen/shescape/blob/main/LICENSE
+[open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md
 [recipes]: docs/recipes.md
 [security]: https://github.com/ericcornelissen/shescape/blob/main/SECURITY.md
 [shell injection]: https://portswigger.net/web-security/os-command-injection

--- a/node_modules/shescape/SECURITY.md
+++ b/node_modules/shescape/SECURITY.md
@@ -21,6 +21,13 @@ To report a security issue, send an email to [security@ericcornelissen.dev] and
 include the words _"SECURITY"_ and _"Shescape"_ in the subject line. Please
 do not open a regular issue or Pull Request in the public repository.
 
+## Advisories
+
+- `CVE-2021-21384` (2021-03-19)
+- `CVE-2022-24725` (2022-03-03)
+- `CVE-2022-31179` (2022-07-26)
+- `CVE-2022-31180` (2022-07-26)
+
 ## Acknowledgments
 
 We would like to publicly thank the following reporters:

--- a/node_modules/shescape/docs/recipes.md
+++ b/node_modules/shescape/docs/recipes.md
@@ -1,0 +1,533 @@
+# Shescape Recipes
+
+This document provides examples, called _recipes_, for how to use Shescape in
+practice.
+
+Please [open an issue] if you found a mistake or if you have a suggestion for
+how to improve the documentation.
+
+## [`node:child_process`]
+
+In this section you can find recipes of how to use Shescape with the Node.js
+built-in module `node:child_process`.
+
+### [`exec`] / [`execSync`]
+
+#### `exec(command, callback)`
+
+When using `child_process.exec` without the `options` argument, use
+`shescape.quote` to escape all user input in the command string.
+
+```js
+import { exec } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Collect user input */
+const userInput = "&& ls";
+
+/* 2. Execute shell command */
+exec(`echo Hello ${shescape.quote(userInput)}`, (error, stdout) => {
+  if (error) {
+    console.error(`An error occurred: ${error}`);
+  } else {
+    console.log(stdout);
+    // Output:  "Hello && ls"
+  }
+});
+```
+
+#### `exec(command, options, callback)`
+
+When using `child_process.exec` with the `options` argument, use
+`shescape.quote` to escape all user input in the command string. Provide the
+`options` argument to `shescape.quote` as well.
+
+```js
+import { exec } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Set up configuration */
+const execOptions = {
+  // Example configuration for `exec`
+  shell: "/bin/bash",
+};
+const shescapeOptions = {
+  // Set options for Shescape first, then add the options for `exec`. DO NOT set
+  // any keys from the child_process API here.
+  ...execOptions,
+};
+
+/* 2. Collect user input */
+const userInput = "&& ls";
+
+/* 3. Execute shell command */
+exec(
+  `echo Hello ${shescape.quote(userInput, shescapeOptions)}`,
+  execOptions,
+  (error, stdout) => {
+    if (error) {
+      console.error(`An error occurred: ${error}`);
+    } else {
+      console.log(stdout);
+      // Output:  "Hello && ls"
+    }
+  }
+);
+```
+
+#### `execSync(command)`
+
+When using `child_process.execSync` without the `options` argument, use
+`shescape.quote` to escape all user input in the command string.
+
+```js
+import { execSync } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Collect user input */
+const userInput = "&& ls";
+
+/* 2. Execute shell command */
+try {
+  const stdout = execSync(`echo Hello ${shescape.quote(userInput)}`);
+  console.log(`${stdout}`);
+  // Output:  "Hello && ls"
+} catch (error) {
+  console.error(`An error occurred: ${error}`);
+}
+```
+
+#### `execSync(command, options)`
+
+When using `child_process.execSync` with the `options` argument, use
+`shescape.quote` to escape all user input in the command string. Provide the
+`options` argument to `shescape.quote` as well.
+
+```js
+import { execSync } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Set up configuration */
+const execOptions = {
+  // Example configuration for `execSync`
+  shell: "/bin/bash",
+};
+const shescapeOptions = {
+  // Set options for Shescape first, then add the options for `execSync`. DO NOT
+  // set any keys from the child_process API here.
+  ...execOptions,
+};
+
+/* 2. Collect user input */
+const userInput = "&& ls";
+
+/* 3. Execute shell command */
+try {
+  const stdout = execSync(
+    `echo Hello ${shescape.quote(userInput, shescapeOptions)}`,
+    execOptions
+  );
+  console.log(`${stdout}`);
+  // Output:  "Hello && ls"
+} catch (error) {
+  console.error(`An error occurred: ${error}`);
+}
+```
+
+#### With `shescape.escape`
+
+If you find yourself in a situation where the inputted argument to `exec` cannot
+be quoted, you can use `shescape.escape` with `interpolation: true` instead.
+
+> **Warning**: If possible, it is advised to rewrite your code so that you can
+> use `shescape.quote` as shown above. Or use a different function from the
+> `child_process` API, as shown further down below.
+
+```js
+import { exec } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Set up configuration */
+const options = {
+  interpolation: true,
+};
+
+/* 2. Collect user input */
+const userInput = "&& ls";
+
+/* 3. Execute shell command */
+exec(`echo Hello ${shescape.escape(userInput, options)}`, (error, stdout) => {
+  if (error) {
+    console.error(`An error occurred: ${error}`);
+  } else {
+    console.log(stdout);
+    // Output:  "Hello && ls"
+  }
+});
+```
+
+### [`execFile`] / [`execFileSync`]
+
+#### `execFile(file, args, callback)`
+
+When using `child_process.execFile` without the `options` argument, use
+`shescape.escapeAll` to escape all `args`.
+
+```js
+import { execFile } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Collect user input */
+const userInput = "\x00world";
+
+/* 2. Execute shell command */
+execFile(
+  "echo",
+  shescape.escapeAll(["Hello", userInput, "!"]),
+  (error, stdout) => {
+    if (error) {
+      console.error(`An error occurred: ${error}`);
+    } else {
+      console.log(stdout);
+      // Output:  "Hello world !"
+    }
+  }
+);
+```
+
+#### `execFile(file, args, options, callback)`
+
+When using `child_process.execFile` with the `options` argument, always provide
+the `options` argument to Shescape as well. If `options.shell` is set to a
+truthy value, use `shescape.quoteAll` to escape all `args`. If `options.shell`
+is set to a falsy value (or omitted), use `shescape.escapeAll` to escape all
+`args`.
+
+```js
+import { execFile } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Set up configuration */
+const execFileOptions = {
+  // Example configuration for `execFile`
+  shell: "/bin/bash",
+};
+const shescapeOptions = {
+  // Set options for Shescape first, then add the options for `execFile`. DO NOT
+  // set any keys from the child_process API here.
+  ...execFileOptions,
+};
+
+/* 2. Collect user input */
+const userInput = "&& ls";
+
+/* 3. Execute shell command */
+execFile(
+  "echo",
+  execFileOptions.shell
+    ? // When the `shell` option is configured, arguments should be quoted
+      shescape.quoteAll(["Hello", userInput], shescapeOptions)
+    : // When the `shell` option is NOT configured, arguments should NOT be quoted
+      shescape.escapeAll(["Hello", userInput], shescapeOptions),
+  execFileOptions,
+  (error, stdout) => {
+    if (error) {
+      console.error(`An error occurred: ${error}`);
+    } else {
+      console.log(stdout);
+      // Output:  "Hello && ls"
+    }
+  }
+);
+```
+
+#### `execFileSync(file, args)`
+
+When using `child_process.execFileSync` without the `options` argument, use
+`shescape.escapeAll` to escape all `args`.
+
+```js
+import { execFileSync } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Collect user input */
+const userInput = "\x00world";
+
+/* 2. Execute shell command */
+try {
+  const stdout = execFileSync(
+    "echo",
+    shescape.escapeAll(["Hello", userInput, "!"])
+  );
+  console.log(`${stdout}`);
+  // Output:  "Hello world !"
+} catch (error) {
+  console.error(`An error occurred: ${error}`);
+}
+```
+
+#### `execFileSync(file, args, options)`
+
+When using `child_process.execFile` with the `options` argument, always provide
+the `options` argument to Shescape as well. If `options.shell` is set to a
+truthy value, use `shescape.quoteAll` to escape all `args`. If `options.shell`
+is set to a falsy value (or omitted), use `shescape.escapeAll` to escape all
+`args`.
+
+> **Warning**: Due to a bug in Node.js (<18.7.0), using `execFileSync` with a
+> shell may result in `args` not being passed properly to the `command`,
+> depending on the shell being used. See [nodejs/node#43333].
+
+```js
+import { execFileSync } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Set up configuration */
+const execFileOptions = {
+  // Example configuration for `execFileSync`
+  shell: "/bin/bash",
+};
+const shescapeOptions = {
+  // Set options for Shescape first, then add the options for `execFileSync`. DO
+  // NOT set any keys from the child_process API here.
+  ...execFileOptions,
+};
+
+/* 2. Collect user input */
+const userInput = "&& ls";
+
+/* 3. Execute shell command */
+try {
+  const stdout = execFileSync(
+    "echo",
+    execFileOptions.shell
+      ? // When the `shell` option is configured, arguments should be quoted
+        shescape.quoteAll(["Hello", userInput], shescapeOptions)
+      : // When the `shell` option is NOT configured, arguments should NOT be quoted
+        shescape.escapeAll(["Hello", userInput], shescapeOptions),
+    execFileOptions
+  );
+  console.log(`${stdout}`);
+  // Output:  "Hello && ls"
+} catch (error) {
+  console.error(`An error occurred: ${error}`);
+}
+```
+
+### [`fork`]
+
+#### `fork(modulePath, args)`
+
+When using `child_process.fork` without the `options` argument, use
+`shescape.escapeAll` to escape all `args`.
+
+```js
+// echo.js
+
+import { fork } from "node:child_process";
+import { argv } from "node:process";
+import * as shescape from "shescape";
+
+if (argv[2] === "Hello") {
+  console.log(`${argv[2]} ${argv[3]} ${argv[4]}`);
+  // Output:  "Hello world !"
+} else {
+  /* 1. Collect user input */
+  const userInput = "\x00world";
+
+  /* 2. Execute a Node.js module */
+  const echo = fork("echo.js", shescape.escapeAll(["Hello", userInput, "!"]));
+  echo.on("error", (error) => {
+    console.error(`An error occurred: ${error}`);
+  });
+}
+```
+
+#### `fork(modulePath, args, options)`
+
+When using `child_process.fork` with the `options` argument, use
+`shescape.escapeAll` to escape all `args`.
+
+```js
+// echo.js
+
+import { fork } from "node:child_process";
+import { argv } from "node:process";
+import * as shescape from "shescape";
+
+if (argv[2] === "Hello") {
+  console.log(`${argv[2]} ${argv[3]} ${argv[4]}`);
+  // Output:  "Hello world !"
+} else {
+  /* 1. Set up configuration */
+  const forkOptions = {
+    // Example configuration for `fork`
+    detached: true,
+  };
+  const shescapeOptions = {
+    // Set options for Shescape first, then add the options for `fork`. DO NOT set
+    // any keys from the child_process API here.
+    ...forkOptions,
+  };
+
+  /* 2. Collect user input */
+  const userInput = "\x00world";
+
+  /* 3. Execute a Node.js module */
+  const echo = fork(
+    "echo.js",
+    shescape.escapeAll(["Hello", userInput, "!"], shescapeOptions),
+    forkOptions
+  );
+  echo.on("error", (error) => {
+    console.error(`An error occurred: ${error}`);
+  });
+}
+```
+
+### [`spawn`] / [`spawnSync`]
+
+#### `spawn(command, args)`
+
+When using `child_process.spawn` without the `options` argument, use
+`shescape.escapeAll` to escape all `args`.
+
+```js
+import { spawn } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Collect user input */
+const userInput = "\x00world";
+
+/* 2. Execute shell command */
+const echo = spawn("echo", shescape.escapeAll(["Hello", userInput, "!"]));
+echo.on("error", (error) => {
+  console.error(`An error occurred: ${error}`);
+});
+echo.stdout.on("data", (data) => {
+  console.log(`${data}`);
+  // Output:  "Hello world !"
+});
+```
+
+#### `spawn(command, args, options)`
+
+When using `child_process.spawn` with the `options` argument, always provide
+the `options` argument to Shescape as well. If `options.shell` is set to a
+truthy value, use `shescape.quoteAll` to escape all `args`. If `options.shell`
+is set to a falsy value (or omitted), use `shescape.escapeAll` to escape all
+`args`.
+
+```js
+import { spawn } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Set up configuration */
+const spawnOptions = {
+  // Example configuration for `spawn`
+  shell: "/bin/bash",
+};
+const shescapeOptions = {
+  // Set options for Shescape first, then add the options for `spawn`. DO NOT
+  // set any keys from the child_process API here.
+  ...spawnOptions,
+};
+
+/* 2. Collect user input */
+const userInput = "&& ls";
+
+/* 3. Execute shell command */
+const echo = spawn(
+  "echo",
+  spawnOptions.shell
+    ? // When the `shell` option is configured, arguments should be quoted
+      shescape.quoteAll(["Hello", userInput], shescapeOptions)
+    : // When the `shell` option is NOT configured, arguments should NOT be quoted
+      shescape.escapeAll(["Hello", userInput], shescapeOptions),
+  spawnOptions
+);
+echo.on("error", (error) => {
+  console.error(`An error occurred: ${error}`);
+});
+echo.stdout.on("data", (data) => {
+  console.log(`${data}`);
+  // Output:  "Hello && ls"
+});
+```
+
+#### `spawnSync(command, args)`
+
+When using `child_process.spawnSync` without the `options` argument, use
+`shescape.escapeAll` to escape all `args`.
+
+```js
+import { spawnSync } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Collect user input */
+const userInput = "\x00world";
+
+/* 2. Execute shell command */
+const echo = spawnSync("echo", shescape.escapeAll(["Hello", userInput, "!"]));
+if (echo.error) {
+  console.error(`An error occurred: ${echo.error}`);
+} else {
+  console.log(`${echo.stdout}`);
+  // Output:  "Hello world !"
+}
+```
+
+#### `spawnSync(command, args, options)`
+
+When using `child_process.spawnSync` with the `options` argument, always provide
+the `options` argument to Shescape as well. If `options.shell` is set to a
+truthy value, use `shescape.quoteAll` to escape all `args`. If `options.shell`
+is set to a falsy value (or omitted), use `shescape.escapeAll` to escape all
+`args`.
+
+```js
+import { spawnSync } from "node:child_process";
+import * as shescape from "shescape";
+
+/* 1. Set up configuration */
+const spawnOptions = {
+  // Example configuration for `spawn`
+  shell: "/bin/bash",
+};
+const shescapeOptions = {
+  // Set options for Shescape first, then add the options for `spawnSync`. DO
+  // NOT set any keys from the child_process API here.
+  ...spawnOptions,
+};
+
+/* 2. Collect user input */
+const userInput = "&& ls";
+
+/* 3. Execute shell command */
+const echo = spawnSync(
+  "echo",
+  spawnOptions.shell
+    ? // When the `shell` option is configured, arguments should be quoted
+      shescape.quoteAll(["Hello", userInput], shescapeOptions)
+    : // When the `shell` option is NOT configured, arguments should NOT be quoted
+      shescape.escapeAll(["Hello", userInput], shescapeOptions),
+  spawnOptions
+);
+if (echo.error) {
+  console.error(`An error occurred: ${echo.error}`);
+} else {
+  console.log(`${echo.stdout}`);
+  // Output:  "Hello && ls"
+}
+```
+
+[`exec`]: https://nodejs.org/api/child_process.html#child_processexeccommand-options-callback
+[`execfile`]: https://nodejs.org/api/child_process.html#child_processexecfilefile-args-options-callback
+[`execsync`]: https://nodejs.org/api/child_process.html#child_processexecsynccommand-options
+[`execfilesync`]: https://nodejs.org/api/child_process.html#child_processexecfilesyncfile-args-options
+[`fork`]: https://nodejs.org/api/child_process.html#child_processforkmodulepath-args-options
+[`node:child_process`]: https://nodejs.org/api/child_process.html
+[`spawn`]: https://nodejs.org/api/child_process.html#child_processspawncommand-args-options
+[`spawnsync`]: https://nodejs.org/api/child_process.html#child_processspawnsynccommand-args-options
+[nodejs/node#43333]: https://github.com/nodejs/node/issues/43333
+[open an issue]: https://github.com/ericcornelissen/shescape/issues/new?labels=documentation&template=documentation.md

--- a/node_modules/shescape/index.cjs
+++ b/node_modules/shescape/index.cjs
@@ -63,13 +63,13 @@ function resolveExecutable({ executable }, { exists, readlink, which }) {
   try {
     executable = which(executable);
   } catch (_) {
-    // for backwards compatibility return the executable even if its location
+    // For backwards compatibility return the executable even if its location
     // cannot be obtained
     return executable;
   }
 
   if (!exists(executable)) {
-    // for backwards compatibility return the executable even if there exists no
+    // For backwards compatibility return the executable even if there exists no
     // file at the specified path
     return executable;
   }
@@ -320,21 +320,23 @@ const binZsh = "zsh";
  * @returns {string} The escaped argument.
  */
 function escapeArgBash(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "");
+  let result = arg.replace(/\0/gu, "");
 
   if (interpolation) {
     result = result
-      .replace(/\\/g, "\\\\")
-      .replace(/\n/g, " ")
-      .replace(/(^|\s)(~|#)/g, "$1\\$2")
-      .replace(/(\*|\?)/g, "\\$1")
-      .replace(/(\$|\;|\&|\|)/g, "\\$1")
-      .replace(/(\(|\)|\<|\>)/g, "\\$1")
-      .replace(/("|'|`)/g, "\\$1")
-      .replace(/\{(?=([^]*?(?:\,|\.)[^]*?)\})/g, "\\{")
-      .replace(/(?<=\=(?:[^]*?:)?)(~)(?=\:|\=|\-|\+|\/|0|\s|$)/g, "\\$1");
+      .replace(/\\/gu, "\\\\")
+      .replace(/\n/gu, " ")
+      .replace(/(^|\s)([#~])/gu, "$1\\$2")
+      .replace(/([*?])/gu, "\\$1")
+      .replace(/([$&;|])/gu, "\\$1")
+      .replace(/([()<>])/gu, "\\$1")
+      .replace(/(["'`])/gu, "\\$1")
+      .replace(/(?<!\{)\{+(?=(?:[^{][^,.]*)?[,.][^}]*\})/gu, (curlyBraces) =>
+        curlyBraces.replace(/\{/gu, "\\{")
+      )
+      .replace(/(?<=[:=])(~)(?=[\s+\-/0:=]|$)/gu, "\\$1");
   } else if (quoted) {
-    result = result.replace(/'/g, `'\\''`);
+    result = result.replace(/'/gu, `'\\''`);
   }
 
   return result;
@@ -349,20 +351,19 @@ function escapeArgBash(arg, interpolation, quoted) {
  * @returns {string} The escaped argument.
  */
 function escapeArgDash(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "");
+  let result = arg.replace(/\0/gu, "");
 
   if (interpolation) {
     result = result
-      .replace(/\\/g, "\\\\")
-      .replace(/\n/g, " ")
-      .replace(/(^|\s)(~|#)/g, "$1\\$2")
-      .replace(/(\*|\?)/g, "\\$1")
-      .replace(/(\$|\;|\&|\|)/g, "\\$1")
-      .replace(/(\(|\)|\<|\>)/g, "\\$1")
-      .replace(/("|'|`)/g, "\\$1")
-      .replace(/\{(?=([^]*?(?:\,|\.)[^]*?)\})/g, "\\{");
+      .replace(/\\/gu, "\\\\")
+      .replace(/\n/gu, " ")
+      .replace(/(^|\s)([#~])/gu, "$1\\$2")
+      .replace(/([*?])/gu, "\\$1")
+      .replace(/([$&;|])/gu, "\\$1")
+      .replace(/([()<>])/gu, "\\$1")
+      .replace(/(["'`])/gu, "\\$1");
   } else if (quoted) {
-    result = result.replace(/'/g, `'\\''`);
+    result = result.replace(/'/gu, `'\\''`);
   }
 
   return result;
@@ -377,20 +378,20 @@ function escapeArgDash(arg, interpolation, quoted) {
  * @returns {string} The escaped argument.
  */
 function escapeArgZsh(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "");
+  let result = arg.replace(/\0/gu, "");
 
   if (interpolation) {
     result = result
-      .replace(/\\/g, "\\\\")
-      .replace(/\n/g, " ")
-      .replace(/(^|\s)(~|#|=)/g, "$1\\$2")
-      .replace(/(\*|\?)/g, "\\$1")
-      .replace(/(\$|\;|\&|\|)/g, "\\$1")
-      .replace(/(\(|\)|\<|\>)/g, "\\$1")
-      .replace(/("|'|`)/g, "\\$1")
-      .replace(/(\[|\]|\{|\})/g, "\\$1");
+      .replace(/\\/gu, "\\\\")
+      .replace(/\n/gu, " ")
+      .replace(/(^|\s)([#=~])/gu, "$1\\$2")
+      .replace(/([*?])/gu, "\\$1")
+      .replace(/([$&;|])/gu, "\\$1")
+      .replace(/([()<>])/gu, "\\$1")
+      .replace(/(["'`])/gu, "\\$1")
+      .replace(/([[\]{}])/gu, "\\$1");
   } else if (quoted) {
-    result = result.replace(/'/g, `'\\''`);
+    result = result.replace(/'/gu, `'\\''`);
   }
 
   return result;
@@ -535,16 +536,16 @@ const binPowerShell = "powershell.exe";
  * @returns {string} The escaped argument.
  */
 function escapeArgCmd(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "").replace(/\n|\r/g, " ");
+  let result = arg.replace(/\0/gu, "").replace(/[\n\r]/gu, " ");
 
   if (interpolation) {
     result = result
-      .replace(/\^/g, "^^")
-      .replace(/(<|>)/g, "^$1")
-      .replace(/(")/g, "^$1")
-      .replace(/(\&|\|)/g, "^$1");
+      .replace(/\^/gu, "^^")
+      .replace(/([<>])/gu, "^$1")
+      .replace(/(")/gu, "^$1")
+      .replace(/([&|])/gu, "^$1");
   } else if (quoted) {
-    result = result.replace(/"/g, `""`);
+    result = result.replace(/"/gu, `""`);
   }
 
   return result;
@@ -560,21 +561,21 @@ function escapeArgCmd(arg, interpolation, quoted) {
  */
 function escapeArgPowerShell(arg, interpolation, quoted) {
   let result = arg
-    .replace(/\u0000/g, "")
-    .replace(/`/g, "``")
-    .replace(/\$/g, "`$");
+    .replace(/\0/gu, "")
+    .replace(/`/gu, "``")
+    .replace(/\$/gu, "`$$");
 
   if (interpolation) {
     result = result
-      .replace(/\n|\r/g, " ")
-      .replace(/(^|\s)((?:\*|[1-6])?)(>)/g, "$1$2`$3")
-      .replace(/(^|\s)(<|@|#|-|\:|\])/g, "$1`$2")
-      .replace(/(,|\;|\&|\|)/g, "`$1")
-      .replace(/(\(|\)|\{|\})/g, "`$1")
-      .replace(/('|’|‘|‛|‚)/g, "`$1")
-      .replace(/("|“|”|„)/g, "`$1");
+      .replace(/[\n\r]/gu, " ")
+      .replace(/(^|[\s\u0085])([*1-6]?)(>)/gu, "$1$2`$3")
+      .replace(/(^|[\s\u0085])([#\-:<@\]])/gu, "$1`$2")
+      .replace(/([&,;|])/gu, "`$1")
+      .replace(/([(){}])/gu, "`$1")
+      .replace(/(['‘’‚‛])/gu, "`$1")
+      .replace(/(["“”„])/gu, "`$1");
   } else if (quoted) {
-    result = result.replace(/("|“|”|„)/g, "$1$1");
+    result = result.replace(/(["“”„])/gu, "$1$1");
   }
 
   return result;
@@ -762,7 +763,7 @@ function getHelpersByPlatform(args) {
  *   cp.spawn("command", shescape.escapeAll(userInput), options);
  *
  * @module shescape
- * @version 1.5.8
+ * @version 1.5.10
  * @license MPL-2.0
  */
 

--- a/node_modules/shescape/index.js
+++ b/node_modules/shescape/index.js
@@ -8,7 +8,7 @@
  *   cp.spawn("command", shescape.escapeAll(userInput), options);
  *
  * @module shescape
- * @version 1.5.8
+ * @version 1.5.10
  * @license MPL-2.0
  */
 

--- a/node_modules/shescape/package.json
+++ b/node_modules/shescape/package.json
@@ -1,32 +1,28 @@
 {
-  "_args": [
-    [
-      "shescape@1.5.8",
-      "/git-message-action"
-    ]
-  ],
-  "_from": "shescape@1.5.8",
-  "_id": "shescape@1.5.8",
+  "_from": "shescape@v1.5.10",
+  "_id": "shescape@1.5.10",
   "_inBundle": false,
-  "_integrity": "sha512-3AHJE7WwVcrf50WPeizCevN5WnXtPpyI5vaAWNhBoq1sazd189CiKlcNyW296asesDOlew1QwDFZ84rt4L8ctQ==",
+  "_integrity": "sha512-0TS8VUloULl9WqinOI7Mhcujl9PnRmfqHFVV+9pWcOUUrzRt5PeH4AG5uXIsFwns7Vba2goGsD1SEjdV+Y8DTg==",
   "_location": "/shescape",
   "_phantomChildren": {},
   "_requested": {
     "type": "version",
     "registry": true,
-    "raw": "shescape@1.5.8",
+    "raw": "shescape@v1.5.10",
     "name": "shescape",
     "escapedName": "shescape",
-    "rawSpec": "1.5.8",
+    "rawSpec": "v1.5.10",
     "saveSpec": null,
-    "fetchSpec": "1.5.8"
+    "fetchSpec": "v1.5.10"
   },
   "_requiredBy": [
+    "#USER",
     "/"
   ],
-  "_resolved": "https://registry.npmjs.org/shescape/-/shescape-1.5.8.tgz",
-  "_spec": "1.5.8",
-  "_where": "/git-message-action",
+  "_resolved": "https://registry.npmjs.org/shescape/-/shescape-1.5.10.tgz",
+  "_shasum": "f5d264ceb1d70d119a77f553b0730a35038a1464",
+  "_spec": "shescape@v1.5.10",
+  "_where": "/mnt/236BF4A2278DBC3C/workspace/_tmp/git-message-action",
   "author": {
     "name": "Eric Cornelissen",
     "email": "ericornelissen@gmail.com",
@@ -35,25 +31,29 @@
   "bugs": {
     "url": "https://github.com/ericcornelissen/shescape/issues"
   },
+  "bundleDependencies": false,
   "dependencies": {
     "which": "^2.0.0"
   },
+  "deprecated": false,
   "description": "simple shell escape library",
   "devDependencies": {
-    "@fast-check/ava": "0.0.1",
+    "@fast-check/ava": "1.0.1",
     "@stryker-mutator/core": "6.1.2",
     "ava": "4.3.1",
     "benchmark": "2.1.4",
-    "c8": "7.11.3",
+    "c8": "7.12.0",
     "depcheck": "1.4.3",
     "dotenv": "16.0.1",
-    "fast-check": "3.0.1",
+    "eslint": "8.22.0",
+    "eslint-plugin-regexp": "1.8.0",
+    "fast-check": "3.1.1",
     "husky": "8.0.1",
     "is-ci": "3.0.1",
     "jsfuzz": "1.0.15",
     "mocha": "9.2.2",
     "prettier": "2.7.1",
-    "rollup": "2.76.0",
+    "rollup": "2.78.1",
     "sinon": "14.0.0",
     "unimported": "1.21.0"
   },
@@ -88,6 +88,7 @@
     "coverage:integration": "npm run _coverage -- --reports-dir=_reports/coverage/integration npm run test:integration",
     "coverage:property": "npm run _coverage -- --reports-dir=_reports/coverage/property npm run test:property",
     "coverage:unit": "npm run _coverage -- --reports-dir=_reports/coverage/unit npm run test:unit",
+    "eslint": "eslint . --ext .js,.cjs",
     "format": "npm run _prettier -- --write",
     "fuzz": "node script/fuzz.js",
     "lint": "npm run _prettier -- --check",
@@ -106,5 +107,5 @@
   },
   "type": "module",
   "typings": "index.d.ts",
-  "version": "1.5.8"
+  "version": "1.5.10"
 }

--- a/node_modules/shescape/src/executables.js
+++ b/node_modules/shescape/src/executables.js
@@ -27,13 +27,13 @@ export function resolveExecutable({ executable }, { exists, readlink, which }) {
   try {
     executable = which(executable);
   } catch (_) {
-    // for backwards compatibility return the executable even if its location
+    // For backwards compatibility return the executable even if its location
     // cannot be obtained
     return executable;
   }
 
   if (!exists(executable)) {
-    // for backwards compatibility return the executable even if there exists no
+    // For backwards compatibility return the executable even if there exists no
     // file at the specified path
     return executable;
   }

--- a/node_modules/shescape/src/unix.js
+++ b/node_modules/shescape/src/unix.js
@@ -41,21 +41,23 @@ const binZsh = "zsh";
  * @returns {string} The escaped argument.
  */
 function escapeArgBash(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "");
+  let result = arg.replace(/\0/gu, "");
 
   if (interpolation) {
     result = result
-      .replace(/\\/g, "\\\\")
-      .replace(/\n/g, " ")
-      .replace(/(^|\s)(~|#)/g, "$1\\$2")
-      .replace(/(\*|\?)/g, "\\$1")
-      .replace(/(\$|\;|\&|\|)/g, "\\$1")
-      .replace(/(\(|\)|\<|\>)/g, "\\$1")
-      .replace(/("|'|`)/g, "\\$1")
-      .replace(/\{(?=([^]*?(?:\,|\.)[^]*?)\})/g, "\\{")
-      .replace(/(?<=\=(?:[^]*?:)?)(~)(?=\:|\=|\-|\+|\/|0|\s|$)/g, "\\$1");
+      .replace(/\\/gu, "\\\\")
+      .replace(/\n/gu, " ")
+      .replace(/(^|\s)([#~])/gu, "$1\\$2")
+      .replace(/([*?])/gu, "\\$1")
+      .replace(/([$&;|])/gu, "\\$1")
+      .replace(/([()<>])/gu, "\\$1")
+      .replace(/(["'`])/gu, "\\$1")
+      .replace(/(?<!\{)\{+(?=(?:[^{][^,.]*)?[,.][^}]*\})/gu, (curlyBraces) =>
+        curlyBraces.replace(/\{/gu, "\\{")
+      )
+      .replace(/(?<=[:=])(~)(?=[\s+\-/0:=]|$)/gu, "\\$1");
   } else if (quoted) {
-    result = result.replace(/'/g, `'\\''`);
+    result = result.replace(/'/gu, `'\\''`);
   }
 
   return result;
@@ -70,20 +72,19 @@ function escapeArgBash(arg, interpolation, quoted) {
  * @returns {string} The escaped argument.
  */
 function escapeArgDash(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "");
+  let result = arg.replace(/\0/gu, "");
 
   if (interpolation) {
     result = result
-      .replace(/\\/g, "\\\\")
-      .replace(/\n/g, " ")
-      .replace(/(^|\s)(~|#)/g, "$1\\$2")
-      .replace(/(\*|\?)/g, "\\$1")
-      .replace(/(\$|\;|\&|\|)/g, "\\$1")
-      .replace(/(\(|\)|\<|\>)/g, "\\$1")
-      .replace(/("|'|`)/g, "\\$1")
-      .replace(/\{(?=([^]*?(?:\,|\.)[^]*?)\})/g, "\\{");
+      .replace(/\\/gu, "\\\\")
+      .replace(/\n/gu, " ")
+      .replace(/(^|\s)([#~])/gu, "$1\\$2")
+      .replace(/([*?])/gu, "\\$1")
+      .replace(/([$&;|])/gu, "\\$1")
+      .replace(/([()<>])/gu, "\\$1")
+      .replace(/(["'`])/gu, "\\$1");
   } else if (quoted) {
-    result = result.replace(/'/g, `'\\''`);
+    result = result.replace(/'/gu, `'\\''`);
   }
 
   return result;
@@ -98,20 +99,20 @@ function escapeArgDash(arg, interpolation, quoted) {
  * @returns {string} The escaped argument.
  */
 function escapeArgZsh(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "");
+  let result = arg.replace(/\0/gu, "");
 
   if (interpolation) {
     result = result
-      .replace(/\\/g, "\\\\")
-      .replace(/\n/g, " ")
-      .replace(/(^|\s)(~|#|=)/g, "$1\\$2")
-      .replace(/(\*|\?)/g, "\\$1")
-      .replace(/(\$|\;|\&|\|)/g, "\\$1")
-      .replace(/(\(|\)|\<|\>)/g, "\\$1")
-      .replace(/("|'|`)/g, "\\$1")
-      .replace(/(\[|\]|\{|\})/g, "\\$1");
+      .replace(/\\/gu, "\\\\")
+      .replace(/\n/gu, " ")
+      .replace(/(^|\s)([#=~])/gu, "$1\\$2")
+      .replace(/([*?])/gu, "\\$1")
+      .replace(/([$&;|])/gu, "\\$1")
+      .replace(/([()<>])/gu, "\\$1")
+      .replace(/(["'`])/gu, "\\$1")
+      .replace(/([[\]{}])/gu, "\\$1");
   } else if (quoted) {
-    result = result.replace(/'/g, `'\\''`);
+    result = result.replace(/'/gu, `'\\''`);
   }
 
   return result;

--- a/node_modules/shescape/src/win.js
+++ b/node_modules/shescape/src/win.js
@@ -33,16 +33,16 @@ const binPowerShell = "powershell.exe";
  * @returns {string} The escaped argument.
  */
 function escapeArgCmd(arg, interpolation, quoted) {
-  let result = arg.replace(/\u0000/g, "").replace(/\n|\r/g, " ");
+  let result = arg.replace(/\0/gu, "").replace(/[\n\r]/gu, " ");
 
   if (interpolation) {
     result = result
-      .replace(/\^/g, "^^")
-      .replace(/(<|>)/g, "^$1")
-      .replace(/(")/g, "^$1")
-      .replace(/(\&|\|)/g, "^$1");
+      .replace(/\^/gu, "^^")
+      .replace(/([<>])/gu, "^$1")
+      .replace(/(")/gu, "^$1")
+      .replace(/([&|])/gu, "^$1");
   } else if (quoted) {
-    result = result.replace(/"/g, `""`);
+    result = result.replace(/"/gu, `""`);
   }
 
   return result;
@@ -58,21 +58,21 @@ function escapeArgCmd(arg, interpolation, quoted) {
  */
 function escapeArgPowerShell(arg, interpolation, quoted) {
   let result = arg
-    .replace(/\u0000/g, "")
-    .replace(/`/g, "``")
-    .replace(/\$/g, "`$");
+    .replace(/\0/gu, "")
+    .replace(/`/gu, "``")
+    .replace(/\$/gu, "`$$");
 
   if (interpolation) {
     result = result
-      .replace(/\n|\r/g, " ")
-      .replace(/(^|\s)((?:\*|[1-6])?)(>)/g, "$1$2`$3")
-      .replace(/(^|\s)(<|@|#|-|\:|\])/g, "$1`$2")
-      .replace(/(,|\;|\&|\|)/g, "`$1")
-      .replace(/(\(|\)|\{|\})/g, "`$1")
-      .replace(/('|’|‘|‛|‚)/g, "`$1")
-      .replace(/("|“|”|„)/g, "`$1");
+      .replace(/[\n\r]/gu, " ")
+      .replace(/(^|[\s\u0085])([*1-6]?)(>)/gu, "$1$2`$3")
+      .replace(/(^|[\s\u0085])([#\-:<@\]])/gu, "$1`$2")
+      .replace(/([&,;|])/gu, "`$1")
+      .replace(/([(){}])/gu, "`$1")
+      .replace(/(['‘’‚‛])/gu, "`$1")
+      .replace(/(["“”„])/gu, "`$1");
   } else if (quoted) {
-    result = result.replace(/("|“|”|„)/g, "$1$1");
+    result = result.replace(/(["“”„])/gu, "$1$1");
   }
 
   return result;

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,9 +27,9 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "shescape": {
-      "version": "1.5.8",
-      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.5.8.tgz",
-      "integrity": "sha512-3AHJE7WwVcrf50WPeizCevN5WnXtPpyI5vaAWNhBoq1sazd189CiKlcNyW296asesDOlew1QwDFZ84rt4L8ctQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/shescape/-/shescape-1.5.10.tgz",
+      "integrity": "sha512-0TS8VUloULl9WqinOI7Mhcujl9PnRmfqHFVV+9pWcOUUrzRt5PeH4AG5uXIsFwns7Vba2goGsD1SEjdV+Y8DTg==",
       "requires": {
         "which": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -24,6 +24,6 @@
   "homepage": "https://github.com/kceb/git-message-action#readme",
   "dependencies": {
     "@actions/core": "^1.9.1",
-    "shescape": "^1.5.8"
+    "shescape": "^1.5.10"
   }
 }


### PR DESCRIPTION
This upgrade includes a patch for [GHSA-gp75-h7j6-5pv3]. However, at this point in time this project isn't affected as it does not call the impacted functions. Hence, it's not necessary to create a release after this is updated.

[GHSA-gp75-h7j6-5pv3]: https://github.com/ericcornelissen/shescape/security/advisories/GHSA-gp75-h7j6-5pv3