### PR TITLE
Bump Node.js runtime from v16 to v20

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -12,7 +12,7 @@ outputs:
   body:
     description: 'The body of the git-message, i.e. everything but the first line'
 runs:
-  using: 'node16'
+  using: 'node20'
   main: 'index.js'
 branding:
   icon: 'git-commit'


### PR DESCRIPTION
Per https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/